### PR TITLE
Update _code.scss

### DIFF
--- a/scss/content/_code.scss
+++ b/scss/content/_code.scss
@@ -49,6 +49,7 @@
   #{$parent-selector} kbd {
     display: inline-block;
     padding: 0.375rem;
+    max-width: 100%;
   }
 
   #{$parent-selector} pre {


### PR DESCRIPTION
If the text is very long and does not contain spaces, the block extends beyond the parent container. The maximum width limits the off-screen behavior.